### PR TITLE
fix unable to build docker image

### DIFF
--- a/packages/staking-ui/package.json
+++ b/packages/staking-ui/package.json
@@ -49,8 +49,10 @@
     "react-app-rewired": "^2.1.8"
   },
   "scripts": {
+    "start": "react-app-rewired start",
     "start:local": "env-cmd -f .env.local react-app-rewired start",
     "start:devnet": "env-cmd -f .env.devnet react-app-rewired start",
+    "build": "react-scripts build",
     "build:local": "env-cmd -f .env.local react-scripts build",
     "build:devnet": "env-cmd -f .env.devnet react-scripts build"
   },


### PR DESCRIPTION
While building the docker image it causes an error
```
docker build -f docker/staking-ui.Dockerfile -t ankrnetwork/bas-staking-ui
```
```
 ---> 0844d8caa397
Step 6/11 : RUN yarn build && cd packages/staking-ui && yarn build
 ---> Running in 750b91030c62
yarn run v1.22.15
$ tsc --build
Done in 29.36s.
yarn run v1.22.15
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command "build" not found.
```